### PR TITLE
Change way to verify the retention user.

### DIFF
--- a/staffeln/api/app.py
+++ b/staffeln/api/app.py
@@ -15,7 +15,7 @@ LOG = log.getLogger(__name__)
 @app.route("/v1/backup", methods=["POST"])
 def backup_id():
     
-    if not "backup_id" in request.args:
+    if "backup_id" not in request.args:
         # Return error if the backup_id argument is not provided.
         return Response(
             "Error: backup_id is missing.", status=403, mimetype="text/plain"


### PR DESCRIPTION
As we were having issue with having access to backup owner user_id while making request to delete backup through the oslo policy, we have changed way to verify the retention user. We will be using following policy which will remove the need to verify the retention user in api side.
```
"owner": "user_id:%(user_id)s"
"backup:delete": "rule:owner or http://199.204.45.131:8808/v1/backup?backup_id=%(id)s"
```
With this, we will be checking if the retention user is the one making the delete request for any backup. If the user is the retention user, he will be allowed to delete the backup else http check will be performed. In http check if the backup_id is present in staffeln database, api will respond with `false` else `true`.