### PR TITLE
Added exception handler for the keystone errors

### DIFF
--- a/staffeln/common/openstack.py
+++ b/staffeln/common/openstack.py
@@ -67,7 +67,7 @@ class OpenstackSDK():
         )
 
 
-    def delete_backup(self, uuid, project_id=None, force=True):
+    def delete_backup(self, uuid, project_id=None, force=False):
         # Note(Alex): v3 is not supporting force delete?
         # conn.block_storage.delete_backup(
         #     project_id=project_id, backup_id=uuid,


### PR DESCRIPTION
An new exception case is added in case the project backup fails due to some other error like keystone unauthorized which we were facing due to staffeln user not having access to the projects in default domain or cgm domain. 
Also delete backup argument for force is set to False i.e. `delete_backup(self, uuid, project_id=None, force=False)` as successful backup cannot have the force argument value to true. `Force=True` is provided when deleting the failed backup.