### PR TITLE
Consider volumes without name

### DIFF
--- a/staffeln/cmd/dbmanage.py
+++ b/staffeln/cmd/dbmanage.py
@@ -47,12 +47,12 @@ def main():
     valid_commands = set(
         [
             "create_schema",
-            "do_upgrade",
+            "upgrade",
         ]
     )
     if not set(sys.argv).intersection(valid_commands):
         sys.argv.append("create_schema")
-        sys.argv.append("do_upgrade")
+        sys.argv.append("upgrade")
 
     service.prepare_service(sys.argv)
     CONF.command.func()

--- a/staffeln/conductor/backup.py
+++ b/staffeln/conductor/backup.py
@@ -263,6 +263,10 @@ class Backup(object):
                 for volume in server.attached_volumes:
                     if not self.filter_by_volume_status(volume["id"], project.id):
                         continue
+                    if "name"  not in volume:
+                        volume_name = volume["id"]
+                    else:
+                        volume_name = volume["name"][:100]
                     queues_map.append(
                         QueueMapping(
                             project_id=project.id,
@@ -273,7 +277,7 @@ class Backup(object):
                             # Only keep the last 100 chars of instance_name and
                             # volume_name for forming backup_name
                             instance_name=server.name[:100],
-                            volume_name=volume["name"][:100],
+                            volume_name=volume_name,
                         )
                     )
         return queues_map
@@ -301,7 +305,7 @@ class Backup(object):
         project_id = queue.project_id
         timestamp = int(datetime.now().timestamp())
         # Backup name allows max 255 chars of string
-        backup_name = ("%(instance_name)s-%(volume_name)s-%(timestamp)s") % {
+        backup_name = ("%(instance_name)s_%(volume_name)s_%(timestamp)s") % {
             "instance_name": queue.instance_name,
             "volume_name": queue.volume_name,
             "timestamp": timestamp,

--- a/staffeln/conductor/backup.py
+++ b/staffeln/conductor/backup.py
@@ -263,7 +263,7 @@ class Backup(object):
                 for volume in server.attached_volumes:
                     if not self.filter_by_volume_status(volume["id"], project.id):
                         continue
-                    if "name"  not in volume:
+                    if "name" not in volume:
                         volume_name = volume["id"]
                     else:
                         volume_name = volume["name"][:100]


### PR DESCRIPTION
- Name is an optional field for Volume. Used volume id in this case when generating backup name.
- Fix typo db in upgrade command at registration